### PR TITLE
Colour small-area buildings blue in voxelization previews

### DIFF
--- a/bridge/3_voxelization.py
+++ b/bridge/3_voxelization.py
@@ -81,11 +81,16 @@ def save_outline_preview(gdf: gpd.GeoDataFrame, case_name: str, shp_path: Path, 
         2, 1, figsize=(8, 8), gridspec_kw={"height_ratios": [4, 1]}
     )
 
-    line_width = 0.25
+    line_width = 0.125
+    areas = gdf.geometry.area
     if "height" in gdf.columns:
-        extruded_mask = gdf["height"].notna() & (gdf["height"] > 0)
+        extruded_mask = (
+            gdf["height"].notna()
+            & (gdf["height"] > 0)
+            & (areas >= MIN_EXTRUDE_AREA)
+        )
     else:
-        extruded_mask = np.ones(len(gdf), dtype=bool)
+        extruded_mask = areas >= MIN_EXTRUDE_AREA
     non_extruded = ~extruded_mask
 
     gdf[extruded_mask].boundary.plot(ax=ax_map, color="black", linewidth=line_width)


### PR DESCRIPTION
## Summary
- Halve preview line width and colour non-extruded buildings semi-transparent blue
- Skip drawing these small-area buildings as if extruded

## Testing
- `python -m py_compile bridge/3_voxelization.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68923b56827883309b93a0c13e8c5240