### PR TITLE
Scale STL geometry for compatibility

### DIFF
--- a/bridge/4_validation.py
+++ b/bridge/4_validation.py
@@ -33,8 +33,12 @@ def default_memory_lbm() -> str:
     except Exception:
         return "20000"
 
+SCALE_BACK = 100.0  # STL coordinates were saved at 1/100 scale
+
+
 def stl_ranges(stl_path: Path) -> dict[str, tuple[float, float, float]]:
     mesh = trimesh.load(stl_path, force="mesh")
+    mesh.apply_scale(SCALE_BACK)
     (xmin, ymin, zmin), (xmax, ymax, zmax) = mesh.bounds
     return {
         "x": (xmin, xmax, xmax - xmin),

--- a/cfdCore/FluidX3D/src/setup.cpp
+++ b/cfdCore/FluidX3D/src/setup.cpp
@@ -241,6 +241,7 @@ void main_setup() {
     println("| Time code: " + now_str() + "                                              |");
 
     if (!mesh) { println("ERROR: failed to load STL"); wait(); exit(-1); }
+    mesh->scale(100.0f); // STL stored at 1/100 scale, restore here
     const float target_lbm_x = units.x(si_size.x); const float scale_geom = target_lbm_x / mesh->get_bounding_box_size().x; mesh->scale(scale_geom);
     mesh->translate(float3(1.0f - mesh->pmin.x, 1.0f - mesh->pmin.y, 1.0f - mesh->pmin.z));
 

--- a/cfdCore/FluidX3D/src/setup_bk.cpp
+++ b/cfdCore/FluidX3D/src/setup_bk.cpp
@@ -24,12 +24,15 @@ void main_setup() { // urban canopy airflow over STL city model (non‑interacti
 	LBM lbm(lbm_N, lbm_nu); // compile with GRAPHICS (without INTERACTIVE_GRAPHICS)
 
 	// ------------------------------------------------------------------- import & scale geometry -----------------------------------------------------------
-	Mesh* mesh = read_stl(get_exe_path() + "../stl/buildings_base.stl");
+        Mesh* mesh = read_stl(get_exe_path() + "../stl/buildings_base.stl");
 
-	// Scale STL so its x‑extent matches 5379.31348 m (converted to LBM units)
-	const float target_lbm_x = units.x(si_size.x);
-	const float scale = target_lbm_x / mesh->get_bounding_box_size().x;
-	mesh->scale(scale);
+        // Restore original scale (STL saved at 1/100)
+        if (mesh) mesh->scale(100.0f);
+
+        // Scale STL so its x‑extent matches 5379.31348 m (converted to LBM units)
+        const float target_lbm_x = units.x(si_size.x);
+        const float scale = target_lbm_x / mesh->get_bounding_box_size().x;
+        mesh->scale(scale);
 
 	// Position model: leave a 1‑cell buffer to the negative boundaries, sit on z = 1
 	mesh->translate(float3(1.0f - mesh->pmin.x,

--- a/cfdCore/FluidX3D/src/setup_sig.cpp
+++ b/cfdCore/FluidX3D/src/setup_sig.cpp
@@ -175,6 +175,7 @@ void main_setup() {
     println("Time code = " + now_str());
 
     if (!mesh) { println("ERROR: failed to load STL"); wait(); exit(-1); }
+    mesh->scale(100.0f); // STL stored at 1/100 scale, restore here
     const float target_lbm_x = units.x(si_size.x); const float scale_geom = target_lbm_x / mesh->get_bounding_box_size().x; mesh->scale(scale_geom);
     mesh->translate(float3(1.0f - mesh->pmin.x, 1.0f - mesh->pmin.y, 1.0f - mesh->pmin.z));
 


### PR DESCRIPTION
## Summary
- Export voxelization STLs at 1/100 scale and record real heights in conf
- Restore STL scale during validation before comparing with WRF data
- Enlarge STL coordinates by 100x when loading in solver setup files

## Testing
- `python -m py_compile bridge/3_voxelization.py bridge/4_validation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934c7dbc588330a397c960ca10ec3b